### PR TITLE
ENH: Add a `WIP` GitHub Actions workflow

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -1,0 +1,18 @@
+name: WIP
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - synchronize
+
+jobs:
+  WIP:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/wip@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a `WIP` GitHub Actions workflow to set PRs in pending state if WIP-related terms are found in the PR title or label.