### PR TITLE
ENH: Trigger labeler workflows from forks

### DIFF
--- a/.github/workflows/issue_body_labeler.yml
+++ b/.github/workflows/issue_body_labeler.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: github/issue-labeler@v2.3
       with:

--- a/.github/workflows/issue_title_labeler.yml
+++ b/.github/workflows/issue_title_labeler.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/pr_path_labeler.yml
+++ b/.github/workflows/pr_path_labeler.yml
@@ -2,12 +2,14 @@ name: label pull request on paths
 # See https://github.com/actions/labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/labeler@main
       with:

--- a/.github/workflows/pr_title_labeler.yml
+++ b/.github/workflows/pr_title_labeler.yml
@@ -1,12 +1,14 @@
 name: label pull request on title
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -1,13 +1,15 @@
 name: WIP
 
 on:
-  pull_request:
+  pull_request_target:
     types:  [edited, labeled, opened, reopened, synchronize, unlabeled]
 
 jobs:
   WIP:
     name: Manage pull requests
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Prevent WIP PRs from being merged
         uses: wow-actions/wip@v1


### PR DESCRIPTION
Trigger labeler workflows from forks: change the GitHub webhook event to a `pull_request_target` event to trigger the PR labeler workflows from forks.

See documentation:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target and
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

Add write permissions for the jobs.