### PR TITLE
BUG: Provide `WIP` workflow with `GITHUB_TOKEN` input

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Prevent WIP PRs from being merged
-        uses: wow-actions/wip@v1
-        env:
+        uses: wow-actions/wip@v1.1.0
+        with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Provide `WIP` workflow with `GITHUB_TOKEN` input.

Fixes:
```
Error: Error: Input required and not supplied: GITHUB_TOKEN
Error: Input required and not supplied: GITHUB_TOKEN
```

raised for example at:
https://github.com/scil-vital/tractolearn/actions/runs/3750304957/jobs/6369844817#step:2:8

Documentation:
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepswith