### PR TITLE
ENH: Add `read` permissions to PR path labeler action workflow

### DIFF
--- a/.github/workflows/pr_path_labeler.yml
+++ b/.github/workflows/pr_path_labeler.yml
@@ -9,9 +9,10 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         # File with label/regex match dictionary


### PR DESCRIPTION
Add `read` permissions to PR path labeler action workflow.

Prefer using a pinned version rather than `main`.