### PR TITLE
ENH: Switch `wip` action provider

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Prevent WIP PRs from being merged
-        uses: wow-actions/wip@v1.1.0
-        with:
+        uses: wip/action@v1
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switch `wip` action provider from `wow-actions` to `wip`.

The ancient action is consistently failing:
https://github.com/scil-vital/tractolearn/actions/runs/3759723611