### PR TITLE
ENH: Allow any `pull_request_target` event type to trigger PR actions

### DIFF
--- a/.github/workflows/pr_path_labeler.yml
+++ b/.github/workflows/pr_path_labeler.yml
@@ -2,8 +2,7 @@ name: label pull request on paths
 # See https://github.com/actions/labeler
 
 on:
-  pull_request_target:
-    types: [opened, edited]
+- pull_request_target
 
 jobs:
   triage:

--- a/.github/workflows/pr_title_labeler.yml
+++ b/.github/workflows/pr_title_labeler.yml
@@ -1,8 +1,7 @@
 name: label pull request on title
 
 on:
-  pull_request_target:
-    types: [opened, edited]
+- pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
Allow any `pull_request_target` event type to trigger PR actions.