### PR TITLE
ENH: Fix `README` file labeler minimatch glob pattern

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -40,7 +40,7 @@ area:visualization:
 type:documentation:
   - doc/**/*
   - documentation
-  - README
+  - README.*
 type:packaging:
   - setup.py
   - setup_helpers.py


### PR DESCRIPTION
Fix `README` file labeler minimatch glob pattern.