### PR TITLE
ENH: Report slowest tests in `GitHub Actions`

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         # tox --sitepackages
         python -c 'import tractolearn'
-        coverage run --source tractolearn -m pytest tractolearn -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+        coverage run --source tractolearn -m pytest tractolearn -o junit_family=xunit2 -v --doctest-modules --durations=10 --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
       uses: actions/upload-artifact@master


### PR DESCRIPTION
Instruct `pytest` to report slowest test times in `GitHub Actions`.