### PR TITLE
ENH: Adopt PEP 396: make the `__version__` property available

### DIFF
--- a/tractolearn/__init__.py
+++ b/tractolearn/__init__.py
@@ -1,0 +1,3 @@
+import pkg_resources
+
+__version__ = pkg_resources.require("tractolearn")[0].version


### PR DESCRIPTION
Adopt PEP 396: make the `__version__` property available to the package.

Documentation:
https://peps.python.org/pep-0396/