### PR TITLE
ENH: Add property to discard logging training to `Comet ML`

### DIFF
--- a/configs/train_config.yaml
+++ b/configs/train_config.yaml
@@ -43,5 +43,7 @@ weights:
 viz: False
 viz_num_batches: 10
 
+# Whether the experiment is to be logged to Comet ML
+log_to_comet: False
 
 num_workers: 24

--- a/tractolearn/config/experiment.py
+++ b/tractolearn/config/experiment.py
@@ -78,6 +78,7 @@ class ExperimentKeys:
     NUM_WORKERS = "num_workers"
     DISTANCE_FUNCTION = "distance_function"
     TO_SWAP = "to_swap"
+    LOG_TO_COMET = "log_to_comet"
 
 
 class ThresholdTestKeys:
@@ -167,6 +168,10 @@ class ExperimentFormatter:
         )
         # Copy the YAML configuration file to the experiment directory
         shutil.copy(config, self.experiment_dir)
+
+    @property
+    def log_to_comet(self):
+        return self.config[ExperimentKeys.LOG_TO_COMET]
 
     def setup_experiment(self):
 

--- a/tractolearn/learning/trainer_manager.py
+++ b/tractolearn/learning/trainer_manager.py
@@ -2,6 +2,7 @@
 import itertools
 import logging
 import sys
+import typing
 from os.path import join as pjoin
 from typing import Tuple
 
@@ -42,7 +43,7 @@ class Trainer:
         input_size: Tuple[int, int],
         isocenter: np.array,
         volume: np.array,
-        experiment_recorder: Experiment,
+        experiment_recorder: typing.Union[Experiment, None],
     ):
 
         self._device = device


### PR DESCRIPTION
Add training configuration flag and the corresponding experiment class property to discard logging the training process to `Comet ML`.

It may be useful for users that do not have a `Comet ML` account or are not willing to log the experiment.

Fixes #46.