### PR TITLE
ENH: Upgrade `issue-labeler` GitHub action version

### DIFF
--- a/.github/workflows/issue_body_labeler.yml
+++ b/.github/workflows/issue_body_labeler.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-    - uses: github/issue-labeler@v2.3
+    - uses: github/issue-labeler@v3
       with:
         # Secret token needed (not sure which permissions though)
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Upgrade `issue-labeler` GitHub action version to `v3`.

Fixes:
```
Node.js 12 actions are deprecated.
Please update the following actions to use Node.js 16:
github/issue-labeler@v2.3.
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

raised for example in:
https://github.com/scil-vital/tractolearn/actions/runs/4204834208