### PR TITLE
ENH: Bump `isort` to version 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
     "black == 22.12",
     "flake8 == 3.9.2",
     "flake8-docstrings == 1.6.0",
-    "isort == 5.8.0",
+    "isort == 5.12.0",
     "pre-commit >= 2.9.0",
 ]
 


### PR DESCRIPTION
Bump `isort` to version 5.12.0.

Fixes:
```
RuntimeError: The Poetry configuration is invalid:
  - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'

[end of output]
```

Raised in:
https://github.com/scil-vital/tractolearn/actions/runs/4325468803/jobs/7551666832#step:4:134