### PR TITLE
ENH: Add `importlib-metadata` dependency for documentation generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     # common dependencies
+    "importlib-metadata",
     "comet-ml == 3.0.0",
     "h5py == 2.10.0",
     "matplotlib >= 2.2.0",


### PR DESCRIPTION
Add `importlib-metadata` dependency to allow generating the package documentation using `readthedocs`.

Fixes:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/tractolearn/envs/latest/lib/python3.7/site-packages/sphinx/config.py", line 350, in eval_config_file
    exec(code, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tractolearn/checkouts/latest/doc/conf.py", line 15, in <module>
    from importlib.metadata import version
ModuleNotFoundError: No module named 'importlib.metadata'
```

raised in:
https://readthedocs.org/projects/tractolearn/builds/19667787/