### PR TITLE
ENH: Transition to Python 3.10

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: ['3.10']
         requires: ['latest']
 
     steps:

--- a/.github/workflows/issue_title_labeler.yml
+++ b/.github/workflows/issue_title_labeler.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install packages
       run: |
         python -m pip install --upgrade --user pip

--- a/.github/workflows/pr_title_labeler.yml
+++ b/.github/workflows/pr_title_labeler.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install packages
       run: |
         python -m pip install --upgrade --user pip

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -15,7 +15,7 @@ jobs:
       # max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: ['3.10']
         requires: ['minimal', 'latest']
 
     steps:
@@ -53,16 +53,6 @@ jobs:
         python -m pip install --upgrade --user pip
         pip install setuptools tox
         pip install -e .[test]
-        # Force upgrading packages to workaround the `scilpy` requested versions
-        pip install --upgrade matplotlib==3.1.0
-        pip install --upgrade numpy==1.23.0
-        # Force upgrading packages to avoid numpy-related built-in type deprecation warnings
-        pip install --upgrade dipy==1.4.1
-        pip install --upgrade fury==0.7.1
-        pip install --upgrade h5py==3.0.0
-        pip install --upgrade nibabel==3.2.1
-        pip install --upgrade scikit-learn==0.24.0
-        pip install --upgrade scipy==1.7.0
         python --version
         pip --version
         pip list

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.8
+  python: python3.10
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Tractography learning.
 ## Installation
 
 To use tractolearn, it is recommended to create a virtual environment using
-python 3.8 that will host the necessary dependencies. Torch tested with an
+python 3.10 that will host the necessary dependencies. Torch tested with an
 NVIDIA RTX 3090 with:
 
 ```sh
-   virtualenv tractolearn_env --python=python3.8
+   virtualenv tractolearn_env --python=python3.10
    source tractolearn_env/bin/activate
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,25 +20,25 @@ dependencies = [
     # common dependencies
     "importlib-metadata",
     "comet-ml == 3.0.0",
-    "h5py == 2.10.0",
-    "matplotlib >= 2.2.0",
-    "numpy >= 1.20.0",
+    "h5py == 3.7.0",
+    "matplotlib == 3.6.0",
+    "numpy == 1.23.0",
     "pandas",
     "pathos",
     "pyyaml",
     "seaborn == 0.11.0",
-    "scikit-learn == 0.22.0",
-    "scipy == 1.4.0",
-    "torch == 1.8.1",
+    "scikit-learn == 1.2.0",
+    "scipy == 1.9.0",
+    "torch == 1.13.0",
     "torchsummary == 1.5.1",
     "tqdm",
     "umap-learn",
     # DWI dependencies
-    "dipy == 1.3.0",
-    "fury == 0.7.1",
-    "nibabel == 3.0.0",
+    "dipy == 1.7.0",
+    "fury == 0.8.0",
+    "nibabel == 4.0.0",
     # Git dependencies
-    "scilpy @ git+https://github.com/scilus/scilpy@1.2.2",
+    "scilpy @ git+https://github.com/scilus/scilpy@eb5d3fbe3cb2697a1ea90fe8ea88512e9686802b",
 ]
 description = "Tractography learning"
 dynamic = ["version"]
@@ -48,16 +48,16 @@ maintainers = [
 ]
 name = "tractolearn"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 test = [
     "hypothesis >= 6.8.0",
-    "pytest == 5.3",
+    "pytest == 7.2.0",
     "pytest-cov",
     "pytest-pep8",
     "pytest-xdist",
-    "pytest_console_scripts",
+    "pytest_console_scripts == 1.3.0",
 ]
 dev = [
     "black == 22.12",
@@ -86,7 +86,7 @@ repository = "https://github.com/scil-vital/tractolearn"
 
 [tool.black]
 line-length = 79
-target-version = ["py38"]
+target-version = ["py310"]
 exclude ='''
 (
   /(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py310
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Transition to Python 3.10.

Bump `scilpy` to eb5d3fb and upgrade dependencies accordingly.

Remove the dependencies force-upgrade in the package testing workflow,
as the versions required by `scilpy` are now modern enough to avoid the
primary issues they intended to fix.

Specifically, fix the BLAS option warning in `numpy` triggered by
`python-spams` when using an earlier version of `numpy`. Fixes:
```
AttributeError: module 'numpy.__config__' has no attribute 'blas_opt_info'

ERROR: Failed building wheel for python-spams
```

reported in:
https://github.com/scil-vital/tractolearn/actions/runs/4901866945/jobs/8753373506#step:5:945

Also, avoid using the `scilpy`-patched `dipy` version installation
issues reporting Cython is not being found by installing a more recent
version of `scilpy` using the commit hash. Fixes

```
RuntimeError: Need cython>=0.29.24 to build extensions but cannot import "Cython"
```

repored in
https://github.com/scil-vital/tractolearn/actions/runs/5384681010/jobs/9772886628#step:5:996