### PR TITLE
BUG: Set Python 3.10 to generate documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 # Build documentation in the doc/ directory with Sphinx
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ dev = [
     "isort == 5.12.0",
     "pre-commit >= 2.9.0",
 ]
+doc = [
+    "sphinx",
+    "sphinx-autodoc-typehints",
+    "sphinx-rtd-theme",
+    # "toml",
+]
 
 [project.scripts]
 ae_bundle_streamlines = "scripts:ae_bundle_streamlines.main"


### PR DESCRIPTION
Set Python 3.10 for documentation generation purposes.

Add the necessary documentation dependencies through the `[doc]` optional dependencies section.