### PR TITLE
ENH: Install `BLAS` and `LAPACK` prior to building package in doc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    pre_create_environment:
+      - sudo apt install libblas-dev liblapack-dev
 
 # Build documentation in the doc/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Install `BLAS` and `LAPACK` prior to building package in documentation configuration.

Fixes:
```
/usr/bin/ld: cannot find -lblas: No such file or directory
/usr/bin/ld: cannot find -llapack: No such file or directory
collect2: error: ld returned 1 exit status
error: Command
"g++ -shared -L/home/docs/.asdf/installs/python/3.10.12/lib -Wl,
-rpath,
/home/docs/.asdf/installs/python/3.10.12/lib
-L/home/docs/.asdf/installs/python/3.10.12/lib -Wl,
-rpath,
/home/docs/.asdf/installs/python/3.10.12/lib build/temp.linux-x86_64-cpython-310/spams_wrap/spams_wrap.o
-L/home/docs/checkouts/readthedocs.org/user_builds/tractolearn/envs/latest/lib
-L/usr/local/lib
-L/usr/lib64
-L/usr/lib
-L/usr/lib/x86_64-linux-gnu
-L/home/docs/.asdf/installs/python/3.10.12/lib
-lstdc++ -lblas -llapack
-o build/lib.linux-x86_64-cpython-310/_spams_wrap.cpython-310-x86_64-linux-gnu.so
-fopenmp" failed with exit status 1
```

reported in
https://readthedocs.org/projects/tractolearn/builds/21176489/