### PR TITLE
ENH: Avoid `sudo` when installing `BLAS` and `LAPACK` in doc build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.10"
   jobs:
     pre_create_environment:
-      - sudo apt install libblas-dev liblapack-dev
+      - apt install libblas-dev liblapack-dev
 
 # Build documentation in the doc/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Avoid `sudo` when installing `BLAS` and `LAPACK` in doc build

Fixes:
```
sudo apt install libblas-dev liblapack-dev
/bin/sh: 1: sudo: not found
```

reported in
https://readthedocs.org/projects/tractolearn/builds/21176904/