### PR TITLE
BUG: Fix installing `apt` packages in documentation build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,9 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-  jobs:
-    pre_create_environment:
-      - apt install libblas-dev liblapack-dev
+  apt_packages:
+    - libblas-dev
+    - liblapack-dev
 
 # Build documentation in the doc/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Fix installing `apt` packages in documentation build config by using the appropriate setting.

Documentation:
https://docs.readthedocs.io/en/stable/config-file/v2.html#build-apt-packages