### PR TITLE
ENH: Add GitHub actions workflow to build documentation on PRs

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -1,0 +1,21 @@
+name: build documentation
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    # paths:
+    #   - "docs/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pull-request-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "tractolearn"


### PR DESCRIPTION
Add GitHub actions workflow to build documentation on PRs.

Documentation:
https://github.com/readthedocs/actions/tree/v1/preview