### PR TITLE
ENH: Require `sphinx < 7.0.0` due to incompatibilities with `rtd-theme`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
     "pre-commit >= 2.9.0",
 ]
 doc = [
-    "sphinx",
+    "sphinx < 7.0.0", # 7.0.0 is incompatible with rtd-theme
     "sphinx-autodoc-typehints",
     "sphinx-rtd-theme",
     # "toml",


### PR DESCRIPTION
Require `sphinx < 7.0.0` due to incompatibilities with `rtd-theme`.

Fixes:
```
sphinx.errors.ThemeError: An error happened in rendering the page devel/coding_style_guideline.
Reason: UndefinedError("'style' is undefined")

Theme error:
An error happened in rendering the page devel/coding_style_guideline.
Reason: UndefinedError("'style' is undefined")
```

reported in:
https://readthedocs.org/projects/tractolearn/builds/21177008/

Documentation/evidence:
https://github.com/readthedocs/sphinx_rtd_theme/blob/1.2.2/setup.cfg#L48