### PR TITLE
BUG: Avoid leaving `importlib.metadata.version` in namespace

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 from datetime import datetime
-from importlib.metadata import version
+from importlib.metadata import version as vers
 
 # import sys
 import tomli
@@ -31,7 +31,7 @@ _email = info["project"]["authors"][1]["email"]
 copyright = f"2022-{datetime.now().year}, {_author}s <{_email}s>"
 author = f"{_author}s"
 
-_version = version(project)
+_version = vers(project)
 # The full version, including alpha/beta/rc tags
 release = _version
 


### PR DESCRIPTION
Avoid leaving `importlib.metadata.version` in namespace: `Sphinx` expects `version` to be a string. Use an alias for the method.

Fixes:
```
  File "/home/docs/checkouts/readthedocs.org/user_builds/tractolearn/envs/latest/lib/python3.10/site-packages/sphinx/util/inventory.py", line 152, in dump
    escape(env.config.version))).encode())
  File "/home/docs/checkouts/readthedocs.org/user_builds/tractolearn/envs/latest/lib/python3.10/site-packages/sphinx/util/inventory.py", line 143, in escape
    return re.sub("\\s+", " ", string)
  File "/home/docs/.asdf/installs/python/3.10.12/lib/python3.10/re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object

Exception occurred:
  File "/home/docs/.asdf/installs/python/3.10.12/lib/python3.10/re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```

reported in:
https://readthedocs.org/projects/tractolearn/builds/21177093/