### PR TITLE
BUG: Fix uses of `LoggerKeys` enum class entries

### DIFF
--- a/scripts/ae_bundle_streamlines.py
+++ b/scripts/ae_bundle_streamlines.py
@@ -368,7 +368,7 @@ def main():
 
     logging.info(args)
 
-    _set_up_logger(pjoin(args.output, LoggerKeys.logger_file_basename.name))
+    _set_up_logger(pjoin(args.output, LoggerKeys.logger_file_basename.value))
 
     checkpoint = torch.load(
         args.model,

--- a/scripts/ae_find_thresholds.py
+++ b/scripts/ae_find_thresholds.py
@@ -256,7 +256,7 @@ def main():
     shutil.copy(args.config_file, experiment_dir)
     device = config[ThresholdTestKeys.DEVICE]
 
-    logger_fname = pjoin(experiment_dir, LoggerKeys.logger_file_basename.name)
+    logger_fname = pjoin(experiment_dir, LoggerKeys.logger_file_basename.value)
     _set_up_logger(logger_fname)
 
     if args.verbose:
@@ -453,10 +453,10 @@ def main():
     streamlines_dict["implausible"] = (X_impl, y_impl)
 
     fname_root = pjoin(
-        experiment_dir, LoggerKeys.latent_plot_fname_label + "_trk"
+        experiment_dir, LoggerKeys.latent_plot_fname_label.value + "_trk"
     )
     fname_root_atlas = pjoin(
-        experiment_dir, LoggerKeys.latent_plot_fname_label + "_trk_atlas"
+        experiment_dir, LoggerKeys.latent_plot_fname_label.value + "_trk_atlas"
     )
 
     if config[ThresholdTestKeys.VIZ]:

--- a/scripts/ae_generate_streamlines.py
+++ b/scripts/ae_generate_streamlines.py
@@ -240,7 +240,7 @@ def main():
 
     logger.info(args)
 
-    _set_up_logger(pjoin(args.output, LoggerKeys.logger_file_basename.name))
+    _set_up_logger(pjoin(args.output, LoggerKeys.logger_file_basename.value))
 
     checkpoint = torch.load(
         args.model,

--- a/scripts/ae_train.py
+++ b/scripts/ae_train.py
@@ -87,7 +87,7 @@ def main():
     )
 
     logger_fname = pjoin(
-        experiment.experiment_dir, LoggerKeys.logger_file_basename.name
+        experiment.experiment_dir, LoggerKeys.logger_file_basename.value
     )
     _set_up_logger(logger_fname)
 


### PR DESCRIPTION
Fix uses of `LoggerKeys` enum class entries: use the intended `value` property consistently.

Fixes:
```
Traceback (most recent call last):
  File "/tractolearn/scripts/ae_find_thresholds.py", line 497, in <module>
    main()
  File "/tractolearn/scripts/ae_find_thresholds.py", line 456, in main
    experiment_dir, LoggerKeys.latent_plot_fname_label + "_trk"
TypeError: unsupported operand type(s) for +: 'LoggerKeys' and 'str'
```

for those appearances where the corresponding enum entry was being used without calling its `name` or `value` property.

Fixes #68.