### PR TITLE
ENH: Add `Sphinx` `argparse` module for script documentation purposes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
 ]
 doc = [
     "sphinx < 7.0.0", # 7.0.0 is incompatible with rtd-theme
+    "sphinx-argparse",
     "sphinx-autodoc-typehints",
     "sphinx-rtd-theme",
     # "toml",


### PR DESCRIPTION
Add `Sphinx` `argparse` module for script documentation purposes.