### PR TITLE
ENH: Remove requirements file `pre-commit` hook sorting unused option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,6 @@ repos:
         exclude: .github/workflows
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: requirements-txt-fixer
-        name: requirements-txt-fixer
-        description: Sorts entries in requirements.txt
       - id: trailing-whitespace
 
   - repo: https://github.com/timothycrosley/isort


### PR DESCRIPTION
Remove requrements file `pre-commit` hook sorting unused option: dependencies are listed in the `pyproject.toml` file, and the option does not apply to the dependencies in the `pyproject.toml` file.