### PR TITLE
ENH: Bump `checkout` GHA to v4 in workflows

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/issue_title_labeler.yml
+++ b/.github/workflows/issue_title_labeler.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'

--- a/.github/workflows/pr_title_labeler.yml
+++ b/.github/workflows/pr_title_labeler.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Bump `checkout` GHA to v4 in workflows.