### PR TITLE
ENH: Fix modules in `index.rst` Sphinx documentation index file

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,5 +4,5 @@ Welcome to the tractolearn documentation!
 .. toctree::
     :maxdepth: 1
 
-    modules/tractolearn
-    scripts/modules
+    modules
+    scripts


### PR DESCRIPTION
Fix the package and script module names in the `index.rst` Sphinx documentation index file so that they can be correctly discovered.

Allows the documentation to be extracted successfully by Sphinx.