### PR TITLE
DOC: Make the documentation link have a text in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Tractography learning.
 
-- Documentation: https://tractolearn.readthedocs.io/en/latest/
+- [Documentation](https://tractolearn.readthedocs.io/en/latest/)
 - [Contributing](.github/CONTRIBUTING.rst)
 
 


### PR DESCRIPTION
Make the documentation link have a text in the `README` file.